### PR TITLE
fix: 번역 후 HTML 구조 깨짐 수정 (tongues#92 포팅)

### DIFF
--- a/src/client/t.ts
+++ b/src/client/t.ts
@@ -16,7 +16,7 @@ const $ = (s: string) => document.querySelectorAll(s);
 type PM = [string, string]; // [open, close]
 const LR = /^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$/;
 let api = "", host = "", loc = "", iloc = "", busy = false, done = false, manual = false, pprompt = "";
-let phs = new Map<string, Map<number, PM>>();
+let phs = new WeakMap<Element, Map<number, PM>>();
 let ob: MutationObserver | null = null, tm: any = null;
 
 function cfg() {
@@ -33,10 +33,12 @@ function cfg() {
 
 // --- Placeholder: mixed-content (text + inline tags) ---
 
+function esc(s: string): string { return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"); }
+
 function toPh(el: Element) {
   const m = new Map<number, PM>(); let i = 0;
   function w(n: Node): string {
-    if (n.nodeType === 3) return n.nodeValue || "";
+    if (n.nodeType === 3) return esc(n.nodeValue || "");
     if (n.nodeType !== 1) return "";
     const e = n as Element, tg = e.tagName;
     if (VD.has(tg)) { m.set(i, [e.outerHTML, ""]); return `<${i++}/>`; }
@@ -63,7 +65,7 @@ function fromPh(t: string, m: Map<number, PM>): string {
 
 function collect(inc: boolean, root?: Element) {
   const txt = new Map<string, Element[]>(), atr = new Map<string, { e: Element; a: string }[]>();
-  phs = new Map(); const hd = new WeakSet<Element>();
+  phs = new WeakMap(); const hd = new WeakSet<Element>();
   const tw = document.createTreeWalker(root || document.body, NodeFilter.SHOW_ELEMENT, { acceptNode(n) {
     const el = n as Element;
     const nt = el.closest(NT);
@@ -88,7 +90,7 @@ function collect(inc: boolean, root?: Element) {
   let n: Node | null;
   while ((n = tw.nextNode())) {
     const el = n as Element; let t: string;
-    if (hd.has(el)) { const r = toPh(el); t = r.t; if (r.h) phs.set(t, r.m); }
+    if (hd.has(el)) { const r = toPh(el); t = r.t; if (r.h) phs.set(el, r.m); }
     else t = el.textContent!.trim();
     if (t && t.length >= 2) { const a = txt.get(t) || []; a.push(el); txt.set(t, a); }
   }
@@ -122,7 +124,7 @@ function apply(tE: Map<string, Element[]>, aE: Map<string, { e: Element; a: stri
       continue;
     }
     const els = tE.get(o);
-    if (els) { const pm = phs.get(o); for (const el of els) {
+    if (els) { for (const el of els) { const pm = phs.get(el);
       if (!el.hasAttribute("data-t")) { el.setAttribute("data-t", o); if (pm?.size) el.setAttribute("data-th", el.innerHTML); }
       if (pm?.size) { const h = fromPh(t, pm); el.innerHTML = h; el.setAttribute("data-tt", h); }
       else { const f = document.createElement("font"); f.setAttribute("data-tf", "1"); f.textContent = t; el.replaceChildren(f); }

--- a/src/lib/translator.ts
+++ b/src/lib/translator.ts
@@ -152,10 +152,13 @@ ${prompt}`,
   });
 
   const responseText = response.content[0].type === "text" ? response.content[0].text : "";
-  const lines = responseText.split("\n").filter((l) => l.trim());
 
-  for (const line of lines) {
-    const match = line.match(/^\[(\d+)\]\s*(.+)$/);
+  // Split by [N] markers to handle multiline responses (#92).
+  // LLM may wrap long translations across multiple lines, so line-by-line
+  // parsing with (.+)$ would only capture the first line and drop the rest.
+  const blocks = responseText.split(/(?=^\[\d+\])/m);
+  for (const block of blocks) {
+    const match = block.match(/^\[(\d+)\]\s*([\s\S]+)$/);
     if (match) {
       const idx = parseInt(match[1]);
       const fixed = fixPlaceholderTags(match[2].trim());

--- a/test/inline-tags.test.ts
+++ b/test/inline-tags.test.ts
@@ -16,10 +16,12 @@ const RX = "x-text,x-html,v-text,v-html,:textContent,:innerHTML".split(",");
 
 type PM = [string, string]; // [open, close]
 
+function esc(s: string): string { return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"); }
+
 function toPh(el: Element) {
   const m = new Map<number, PM>(); let i = 0;
   function w(n: Node): string {
-    if (n.nodeType === 3) return n.nodeValue || "";
+    if (n.nodeType === 3) return esc(n.nodeValue || "");
     if (n.nodeType !== 1) return "";
     const e = n as Element, tg = e.tagName;
     if (VD.has(tg)) { m.set(i, [e.outerHTML, ""]); return `<${i++}/>`; }
@@ -285,5 +287,132 @@ describe("full roundtrip (toPh → translate → fromPh)", () => {
     el.innerHTML = originalHtml;
     expect(el.innerHTML).toBe(originalHtml);
     expect(el.textContent).toBe("Use data-tongues-ignore attribute");
+  });
+});
+
+// --- Issue #92: toPh escapes literal < and > from decoded entities ---
+
+describe("toPh entity escaping (#92)", () => {
+  test("&lt; and &gt; in text nodes become &lt; and &gt; in placeholder text", () => {
+    const el = createElement(
+      '<p><a href="#" id="next">&lt; newer</a> · <span id="current-date">2026-03-12 (1/18)</span> · <a href="#" id="prev">older &gt;</a></p>'
+    );
+    const { t } = toPh(el);
+    // < and > from decoded entities must be escaped so they don't collide with <0>...</0> tags
+    expect(t).toContain("&lt; newer");
+    expect(t).toContain("older &gt;");
+    expect(t).not.toMatch(/(?<!&[lg]t);\s*newer/); // no raw < before newer
+  });
+});
+
+// --- Issue #92 full scenario: p with multiple a/span children ---
+
+describe("issue #92 fromPh with escaped entities", () => {
+  test("restores all child elements from placeholder map with escaped < and >", () => {
+    const m = new Map<number, PM>([
+      [0, ['<a href="#" id="next" style="opacity: 0.3;">', "</a>"]],
+      [1, ['<span id="current-date">', "</span>"]],
+      [2, ['<a href="#" id="prev" style="opacity: 1;">', "</a>"]],
+      [3, ['<a href="#" id="today">', "</a>"]],
+      [4, ['<a href="#" id="random">', "</a>"]],
+    ]);
+    const translated = "<0>&lt; 新しい</0> · <1>2026-03-12 (1/18)</1> · <2>古い &gt;</2> · <3>今日</3> · <4>ランダム</4>";
+    const html = fromPh(translated, m);
+    // Must restore all child elements with attributes
+    expect(html).toContain('<a href="#" id="next"');
+    expect(html).toContain('<span id="current-date">');
+    expect(html).toContain('<a href="#" id="prev"');
+    expect(html).toContain('<a href="#" id="today">');
+    expect(html).toContain('<a href="#" id="random">');
+    // Must unescape &lt; and &gt; back to display correctly in innerHTML
+    expect(html).toContain("&lt; 新しい");
+    expect(html).toContain("古い &gt;");
+  });
+});
+
+describe("full roundtrip issue #92 scenario", () => {
+  test("p with multiple inline children: toPh → translate → fromPh preserves DOM structure", () => {
+    const el = createElement(
+      '<p><a href="#" id="next" style="opacity: 0.3;">&lt; newer</a> · <span id="current-date">2026-03-12 (1/18)</span> · <a href="#" id="prev" style="opacity: 1;">older &gt;</a> · <a href="#" id="today">today</a> · <a href="#" id="random">random</a></p>'
+    );
+    const { t, m } = toPh(el);
+    // Simulated translation (Japanese)
+    const translated = "<0>&lt; 新しい</0> · <1>2026-03-12 (1/18)</1> · <2>古い &gt;</2> · <3>今日</3> · <4>ランダム</4>";
+    const html = fromPh(translated, m);
+    // All 5 elements must be present with their attributes
+    expect(html).toContain('<a href="#" id="next"');
+    expect(html).toContain('<span id="current-date">');
+    expect(html).toContain('<a href="#" id="prev"');
+    expect(html).toContain('<a href="#" id="today">');
+    expect(html).toContain('<a href="#" id="random">');
+    // Content must be translated
+    expect(html).toContain("新しい");
+    expect(html).toContain("古い");
+    expect(html).toContain("今日");
+    expect(html).toContain("ランダム");
+  });
+});
+
+// --- Fix #3: phs Map key collision when same text appears in multiple elements ---
+
+describe("phs element-based keying (#92 fix 3)", () => {
+  test("two elements with identical text structure get independent placeholder maps", () => {
+    // Simulate two <p> elements with the same text but different attributes on children
+    const el1 = createElement('<p><a href="/page1" class="link1">Click here</a> for info</p>');
+    const el2 = createElement('<p><a href="/page2" class="link2">Click here</a> for info</p>');
+
+    const r1 = toPh(el1);
+    const r2 = toPh(el2);
+
+    // Both produce the same placeholder text
+    expect(r1.t).toBe(r2.t);
+    expect(r1.t).toBe("<0>Click here</0> for info");
+
+    // But the placeholder maps should contain different opening tags
+    expect(r1.m.get(0)![0]).toContain('href="/page1"');
+    expect(r1.m.get(0)![0]).toContain('class="link1"');
+    expect(r2.m.get(0)![0]).toContain('href="/page2"');
+    expect(r2.m.get(0)![0]).toContain('class="link2"');
+
+    // With a text-keyed Map, phs.set(t, r2.m) would overwrite r1.m
+    // With element-keyed WeakMap, each element keeps its own map
+    const phs = new WeakMap<Element, Map<number, PM>>();
+    phs.set(el1, r1.m);
+    phs.set(el2, r2.m);
+
+    // Both should be independently retrievable
+    const pm1 = phs.get(el1)!;
+    const pm2 = phs.get(el2)!;
+    expect(pm1.get(0)![0]).toContain('href="/page1"');
+    expect(pm2.get(0)![0]).toContain('href="/page2"');
+
+    // Translating each should produce different HTML
+    const translated = "<0>ここをクリック</0> 情報";
+    const html1 = fromPh(translated, pm1);
+    const html2 = fromPh(translated, pm2);
+    expect(html1).toContain('href="/page1"');
+    expect(html1).toContain('class="link1"');
+    expect(html2).toContain('href="/page2"');
+    expect(html2).toContain('class="link2"');
+  });
+
+  test("with old text-keyed Map, second element overwrites first (regression proof)", () => {
+    const el1 = createElement('<p><a href="/page1">Click here</a> for info</p>');
+    const el2 = createElement('<p><a href="/page2">Click here</a> for info</p>');
+
+    const r1 = toPh(el1);
+    const r2 = toPh(el2);
+
+    // Demonstrate the old bug: text-keyed Map causes overwrite
+    const oldPhs = new Map<string, Map<number, PM>>();
+    oldPhs.set(r1.t, r1.m);
+    oldPhs.set(r2.t, r2.m); // overwrites r1.m because r1.t === r2.t
+
+    // Only one entry in the Map — el1's data is lost
+    expect(oldPhs.size).toBe(1);
+    const pm = oldPhs.get(r1.t)!;
+    // pm is r2's map, not r1's
+    expect(pm.get(0)![0]).toContain('href="/page2"');
+    expect(pm.get(0)![0]).not.toContain('href="/page1"');
   });
 });


### PR DESCRIPTION
## Summary
- **80x24/tongues#92** 핫픽스를 open-tongues에 포팅
- `toPh`에서 텍스트 노드의 `<`/`>`를 이스케이프하여 placeholder 태그 충돌 방지
- `claudeTranslate` 멀티라인 LLM 응답 파싱 수정 — `[N]` 블록 단위 분리
- `phs` Map을 `WeakMap<Element>`로 전환하여 동일 텍스트 요소 간 키 충돌 방지

## Test plan
- [x] `bun test` — 75 pass, 0 fail
- [ ] `&lt;`/`&gt;` 엔티티 포함 인라인 요소 번역 후 DOM 구조 유지 확인
- [ ] 긴 placeholder 텍스트의 멀티라인 LLM 응답 파싱 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)