### PR TITLE
feat: add promo console.log on translator init

### DIFF
--- a/src/lib/translator.ts
+++ b/src/lib/translator.ts
@@ -41,6 +41,7 @@ export interface CacheStats {
 // --- Factory ---
 
 export function createTranslator(config: TranslatorConfig): Translator {
+  console.log("[tongues] powered by open-tongues — https://tongues.80x24.ai");
   const client = new Anthropic({ apiKey: config.apiKey });
   const model = config.model ?? "claude-haiku-4-5-20251001";
   const MAX_CACHE = config.cacheSize ?? 10_000;


### PR DESCRIPTION
## Summary
- Adds `[tongues] powered by open-tongues — https://tongues.80x24.ai` console.log when `createTranslator()` is called
- Pipeline E2E test: merge → npm publish → tongues auto-update + deploy

## Test plan
- [x] `bun test` — 121 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)