### PR TITLE
fix: raw placeholder markers shown for duplicate inline elements

### DIFF
--- a/src/client/t.ts
+++ b/src/client/t.ts
@@ -126,7 +126,8 @@ function apply(tE: Map<string, Element[]>, aE: Map<string, { e: Element; a: stri
       continue;
     }
     const els = tE.get(o);
-    if (els) { for (const el of els) { const pm = phs.get(el);
+    if (els) { for (const el of els) { let pm = phs.get(el);
+      if (!pm?.size && el.children.length > 0) { const r = toPh(el); if (r.h) pm = r.m; }
       if (!el.hasAttribute("data-t")) { el.setAttribute("data-t", o); if (pm?.size) el.setAttribute("data-th", el.innerHTML); }
       if (pm?.size) { const h = fromPh(t, pm); el.innerHTML = h; el.setAttribute("data-tt", h); }
       else { const f = document.createElement("font"); f.setAttribute("data-tf", "1"); f.textContent = t; el.replaceChildren(f); }


### PR DESCRIPTION
## Problem
When multiple elements share the same placeholder text (e.g. `<i>▲</i>` icons in nav buttons), only the first element's placeholder map was stored in the `phs` WeakMap during `collect()`. In `apply()`, remaining elements fell through to the `textContent` branch, rendering raw `<0>▲</0>` markers visible to users.

## Fix
In `apply()`, if an element has children but no entry in `phs`, call `toPh()` on-the-fly to rebuild its placeholder map before applying the translation.

## Test
All 142 existing tests pass. The fix was verified on menupie dev server where nav buttons with `<i>` icons were showing raw placeholder markers after translation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>