### PR TITLE
refactor: raw innerHTML instead of numbered placeholders

### DIFF
--- a/src/client/t.ts
+++ b/src/client/t.ts
@@ -14,10 +14,8 @@ const RX = "x-text,x-html,v-text,v-html,:textContent,:innerHTML".split(",");
 const NT = '.notranslate,[translate="no"]';
 const $ = (s: string) => document.querySelectorAll(s);
 
-type PM = [string, string]; // [open, close]
 const LR = /^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$/;
 let api = "", host = "", loc = "", iloc = "", busy = false, done = false, manual = false, pprompt = "", slang = "";
-let phs = new WeakMap<Element, Map<number, PM>>();
 let ob: MutationObserver | null = null, tm: any = null, queued = false;
 
 function cfg() {
@@ -33,41 +31,11 @@ function cfg() {
   return true;
 }
 
-// --- Placeholder: mixed-content (text + inline tags) ---
-
-function esc(s: string): string { return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"); }
-
-function toPh(el: Element) {
-  const m = new Map<number, PM>(); let i = 0;
-  function w(n: Node): string {
-    if (n.nodeType === 3) return esc(n.nodeValue || "");
-    if (n.nodeType !== 1) return "";
-    const e = n as Element, tg = e.tagName;
-    if (VD.has(tg)) { m.set(i, [e.outerHTML, ""]); return `<${i++}/>`; }
-    if (IL.has(tg)) {
-      const j = i++, mt = e.outerHTML.match(/^<[^>]+>/);
-      m.set(j, [mt ? mt[0] : `<${tg.toLowerCase()}>`, `</${tg.toLowerCase()}>`]);
-      let s = ""; for (const c of e.childNodes) s += w(c); return `<${j}>${s}</${j}>`;
-    }
-    let s = ""; for (const c of e.childNodes) s += w(c); return s;
-  }
-  let t = ""; for (const c of el.childNodes) t += w(c);
-  return { t: t.trim(), m, h: m.size > 0 };
-}
-
-function fromPh(t: string, m: Map<number, PM>): string {
-  let r = t.replace(/<(\d+)\/>/g, (_, i) => m.get(+i)?.[0] || ""), ok = true;
-  while (ok) { ok = false; r = r.replace(/<(\d+)>(.*?)<\/\1>/gs, (_, i, c) => {
-    ok = true; const e = m.get(+i); return e ? e[0] + c + e[1] : c; }); }
-  r = r.replace(/<\/?(\d+)\s*\/?>/g, "");
-  return r;
-}
-
 // --- Collect ---
 
 function collect(inc: boolean, root?: Element) {
   const txt = new Map<string, Element[]>(), atr = new Map<string, { e: Element; a: string }[]>();
-  phs = new WeakMap(); const hd = new WeakSet<Element>();
+  const hd = new WeakSet<Element>();
   const tw = document.createTreeWalker(root || document.body, NodeFilter.SHOW_ELEMENT, { acceptNode(n) {
     const el = n as Element;
     const nt = el.closest(NT);
@@ -92,7 +60,7 @@ function collect(inc: boolean, root?: Element) {
   let n: Node | null;
   while ((n = tw.nextNode())) {
     const el = n as Element; let t: string;
-    if (hd.has(el)) { const r = toPh(el); t = r.t; if (r.h) phs.set(el, r.m); }
+    if (hd.has(el)) t = el.innerHTML.trim();
     else t = el.textContent!.trim();
     if (t && t.length >= 2) { const a = txt.get(t) || []; a.push(el); txt.set(t, a); }
   }
@@ -121,16 +89,27 @@ function fi(el: Element) {
 function apply(tE: Map<string, Element[]>, aE: Map<string, { e: Element; a: string }[]>, tr: Map<string, string>) {
   ps(); try { for (const [o, t] of tr) {
     if (o === t) {
-      for (const el of tE.get(o) || []) { if (!el.hasAttribute("data-t")) el.setAttribute("data-t", o); el.classList.remove("t-ing"); }
+      for (const el of tE.get(o) || []) {
+        if (!el.hasAttribute("data-t")) {
+          el.setAttribute("data-t", o);
+          if (el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
+        }
+        el.classList.remove("t-ing");
+      }
       for (const { e, a } of aE.get(o) || []) if (!e.hasAttribute(`data-ta-${a}`)) e.setAttribute(`data-ta-${a}`, o);
       continue;
     }
     const els = tE.get(o);
-    if (els) { for (const el of els) { let pm = phs.get(el);
-      if (!pm?.size && el.children.length > 0) { const r = toPh(el); if (r.h) pm = r.m; }
-      if (!el.hasAttribute("data-t")) { el.setAttribute("data-t", o); if (pm?.size) el.setAttribute("data-th", el.innerHTML); }
-      if (pm?.size) { const h = fromPh(t, pm); el.innerHTML = h; el.setAttribute("data-tt", h); }
-      else { const f = document.createElement("font"); f.setAttribute("data-tf", "1"); f.textContent = t; el.replaceChildren(f); }
+    if (els) { for (const el of els) {
+      if (!el.hasAttribute("data-t")) {
+        el.setAttribute("data-t", o);
+        if (el.hasAttribute("data-th") || el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
+      }
+      if (el.hasAttribute("data-th")) {
+        el.innerHTML = t; el.setAttribute("data-tt", t);
+      } else {
+        const f = document.createElement("font"); f.setAttribute("data-tf", "1"); f.textContent = t; el.replaceChildren(f);
+      }
       fi(el);
     } }
     for (const { e, a } of aE.get(o) || []) { if (!e.hasAttribute(`data-ta-${a}`)) e.setAttribute(`data-ta-${a}`, o); e.setAttribute(a, t); }

--- a/src/lib/translator.ts
+++ b/src/lib/translator.ts
@@ -123,19 +123,14 @@ export function createTranslator(config: TranslatorConfig): Translator {
           role: "user",
           content: `Translate every numbered text below into ${targetLang}. The source texts may be in any language — detect each one individually and translate it to ${targetLang}. Keep the [N] numbering. Output only the translated lines, no explanations.
 
-IMPORTANT — Placeholder tags like <0>, </0>, <1>, </1>, <2>, </2> are NOT HTML. They are opaque tokens that MUST appear in your output exactly as written. Never rename, rewrite, or spell out the numbers (e.g. do NOT change <0> to <zero>).
-CRITICAL — If a source text contains NO placeholder tags, your translation MUST also contain NO placeholder tags. Never invent or add tags that do not exist in the input.
-  Example with tags:
-    Input:  [0] <0>Email address:</0> Provided during registration.
-    Output: [0] <0>メールアドレス：</0> 登録時に提供されます。
-  Example without tags:
-    Input:  [1] Read-only. Current translation locale (e.g. "en", "ja").
-    Output: [1] 읽기 전용입니다. 현재 번역 언어입니다 (예: "en", "ja").
+Some texts may contain HTML tags (e.g. <strong>, <a href="...">, <br>).
+Preserve all HTML tags and their attributes exactly as written.
+If a source text has NO HTML tags, your translation MUST also have NO HTML tags.
 
 ${prompt}`,
         },
       ],
-      system: `You are a website translator. Target: ${targetLang} (${to}).${context?.from ? ` Likely source: ${langName(context.from)}.` : ""} Rules: 1) Every text MUST be translated to ${targetLang} — never return the source text unchanged unless it is already valid ${targetLang}. 2) Texts may come from different source languages in one batch. 3) Only preserve brand names, product names, and technical terms (URLs, code, variable names) in their original form. 4) Preserve numbered placeholder tags (<0>...</0>, <1/>, etc.) exactly — but NEVER add placeholder tags to text that has none. 5) Keep translations concise and natural for web UI.${context?.pageTitle ? ` Page: "${context.pageTitle}${context?.pageDescription ? ` — ${context.pageDescription}` : ""}".` : ""}${context?.preprompt ? ` Note: ${context.preprompt}` : ""}`,
+      system: `You are a website translator. Target: ${targetLang} (${to}).${context?.from ? ` Likely source: ${langName(context.from)}.` : ""} Rules: 1) Every text MUST be translated to ${targetLang} — never return the source text unchanged unless it is already valid ${targetLang}. 2) Texts may come from different source languages in one batch. 3) Only preserve brand names, product names, and technical terms (URLs, code, variable names) in their original form. 4) Preserve all HTML tags and attributes exactly — but NEVER add HTML tags to text that has none. 5) Keep translations concise and natural for web UI.${context?.pageTitle ? ` Page: "${context.pageTitle}${context?.pageDescription ? ` — ${context.pageDescription}` : ""}".` : ""}${context?.preprompt ? ` Note: ${context.preprompt}` : ""}`,
     });
 
     const responseText = response.content[0].type === "text" ? response.content[0].text : "";
@@ -148,9 +143,9 @@ ${prompt}`,
       const match = block.match(/^\[(\d+)\]\s*([\s\S]+)$/);
       if (match) {
         const idx = parseInt(match[1]);
-        const fixed = fixPlaceholderTags(match[2].trim());
+        const translated = match[2].trim();
         if (idx < texts.length) {
-          result[texts[idx]] = stripPhantomTags(texts[idx], fixed);
+          result[texts[idx]] = stripPhantomHtml(texts[idx], translated);
         }
       }
     }
@@ -192,7 +187,7 @@ ${prompt}`,
       const sqliteVal = sqliteResults[i];
       if (sqliteVal) {
         sqliteHits++;
-        const clean = stripPhantomTags(text, sqliteVal);
+        const clean = stripPhantomHtml(text, sqliteVal);
         result[text] = clean;
         storeCache(domain, to, text, clean);
       } else {
@@ -272,30 +267,10 @@ function langName(code: string): string {
   return LANG_NAMES[code] || code;
 }
 
-const PH_TAG_RE = /<\/?(\d+)\s*\/?>/;
-
-function stripPhantomTags(original: string, translated: string): string {
-  if (PH_TAG_RE.test(original)) return translated;
-  return translated.replace(/<\/?(\d+)\s*\/?>/g, "");
-}
-
-const WORD_TO_DIGIT: Record<string, string> = {
-  zero: "0", one: "1", two: "2", three: "3", four: "4",
-  five: "5", six: "6", seven: "7", eight: "8", nine: "9",
-  ten: "10", eleven: "11", twelve: "12", thirteen: "13",
-  fourteen: "14", fifteen: "15",
-};
-const TAG_FIX_RE = new RegExp(
-  `<(/?)(${Object.keys(WORD_TO_DIGIT).join("|")})(/)?>`,
-  "gi"
-);
-
-function fixPlaceholderTags(text: string): string {
-  return text.replace(TAG_FIX_RE, (_, slash1, word, slash2) => {
-    const digit = WORD_TO_DIGIT[word.toLowerCase()];
-    if (!digit) return _;
-    return `<${slash1 || ""}${digit}${slash2 || ""}>`;
-  });
+/** If original has no `<`, strip any HTML tags the LLM hallucinated */
+function stripPhantomHtml(original: string, translated: string): string {
+  if (original.includes("<")) return translated;
+  return translated.replace(/<[^>]+>/g, "");
 }
 
 // --- Legacy exports for standalone server (backward compat) ---

--- a/test/inline-tags.test.ts
+++ b/test/inline-tags.test.ts
@@ -2,47 +2,14 @@ import { describe, test, expect } from "bun:test";
 import { parseHTML } from "linkedom";
 
 /**
- * Unit tests for tongues placeholder system.
- * Replicates the core functions from t.ts (which has no exports)
- * to verify mixed-content translation works correctly.
+ * Unit tests for tongues inline HTML approach (Approach C).
+ * Mixed-content elements send innerHTML directly to the LLM.
+ * No placeholder numbering — HTML tags are preserved as-is.
  */
-
-// --- Replicate constants and functions from t.ts ---
 
 const IL = new Set("STRONG,EM,B,I,U,S,CODE,A,SPAN,MARK,SUB,SUP,SMALL,ABBR,CITE,DFN,TIME,Q".split(","));
 const VD = new Set("BR,IMG,WBR".split(","));
-const SK = new Set("SCRIPT,STYLE,NOSCRIPT,SVG,TEMPLATE,CODE,PRE,KBD,SAMP,VAR,CANVAS,VIDEO,AUDIO,IFRAME,MATH".split(","));
 const RX = "x-text,x-html,v-text,v-html,:textContent,:innerHTML".split(",");
-
-type PM = [string, string]; // [open, close]
-
-function esc(s: string): string { return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"); }
-
-function toPh(el: Element) {
-  const m = new Map<number, PM>(); let i = 0;
-  function w(n: Node): string {
-    if (n.nodeType === 3) return esc(n.nodeValue || "");
-    if (n.nodeType !== 1) return "";
-    const e = n as Element, tg = e.tagName;
-    if (VD.has(tg)) { m.set(i, [e.outerHTML, ""]); return `<${i++}/>`; }
-    if (IL.has(tg)) {
-      const j = i++, mt = e.outerHTML.match(/^<[^>]+>/);
-      m.set(j, [mt ? mt[0] : `<${tg.toLowerCase()}>`, `</${tg.toLowerCase()}>`]);
-      let s = ""; for (const c of e.childNodes) s += w(c); return `<${j}>${s}</${j}>`;
-    }
-    let s = ""; for (const c of e.childNodes) s += w(c); return s;
-  }
-  let t = ""; for (const c of el.childNodes) t += w(c);
-  return { t: t.trim(), m, h: m.size > 0 };
-}
-
-function fromPh(t: string, m: Map<number, PM>): string {
-  let r = t.replace(/<(\d+)\/>/g, (_, i) => m.get(+i)?.[0] || ""), ok = true;
-  while (ok) { ok = false; r = r.replace(/<(\d+)>(.*?)<\/\1>/gs, (_, i, c) => {
-    ok = true; const e = m.get(+i); return e ? e[0] + c + e[1] : c; }); }
-  r = r.replace(/<\/?(\d+)\s*\/?>/g, "");
-  return r;
-}
 
 function inlineOnly(el: Element): boolean {
   for (const c of el.children) {
@@ -52,150 +19,179 @@ function inlineOnly(el: Element): boolean {
   return true;
 }
 
-// --- Helper ---
-
 function createElement(html: string): Element {
   const { document } = parseHTML(`<!DOCTYPE html><html><body>${html}</body></html>`);
   return document.body.firstElementChild!;
 }
 
-// --- toPh: extract placeholders ---
+function makeDoc(html: string) {
+  return parseHTML(`<!DOCTYPE html><html><body>${html}</body></html>`);
+}
 
-describe("toPh (htmlToPlaceholder)", () => {
-  test("plain text — no inline tags", () => {
+// --- collect: innerHTML extraction for mixed-content ---
+
+describe("collect: innerHTML for mixed-content", () => {
+  test("plain text — uses textContent", () => {
     const el = createElement("<p>Hello world</p>");
-    const { t, m, h } = toPh(el);
-    expect(t).toBe("Hello world");
-    expect(h).toBe(false);
-    expect(m.size).toBe(0);
+    expect(el.children.length).toBe(0);
+    expect(el.textContent!.trim()).toBe("Hello world");
   });
 
-  test("single <strong> tag", () => {
+  test("single <strong> — uses innerHTML", () => {
     const el = createElement("<p>This is <strong>important</strong> text</p>");
-    const { t, m, h } = toPh(el);
-    expect(t).toBe("This is <0>important</0> text");
-    expect(h).toBe(true);
-    expect(m.get(0)![0]).toBe("<strong>");
-    expect(m.get(0)![1]).toBe("</strong>");
+    expect(el.children.length).toBeGreaterThan(0);
+    expect(inlineOnly(el)).toBe(true);
+    expect(el.innerHTML.trim()).toBe("This is <strong>important</strong> text");
   });
 
-  test("single <code> tag", () => {
-    const el = createElement("<p>Use <code>data-tongues-ignore</code> attribute</p>");
-    const { t, m } = toPh(el);
-    expect(t).toBe("Use <0>data-tongues-ignore</0> attribute");
-    expect(m.get(0)![0]).toBe("<code>");
-  });
-
-  test("<a> tag with href preserved", () => {
+  test("<a> with href — innerHTML preserves attributes", () => {
     const el = createElement('<p>Visit <a href="https://example.com">our site</a> now</p>');
-    const { t, m } = toPh(el);
-    expect(t).toBe("Visit <0>our site</0> now");
-    expect(m.get(0)![0]).toBe('<a href="https://example.com">');
-    expect(m.get(0)![1]).toBe("</a>");
+    expect(inlineOnly(el)).toBe(true);
+    const html = el.innerHTML.trim();
+    expect(html).toContain('<a href="https://example.com">');
+    expect(html).toContain("our site</a>");
   });
 
-  test("multiple sibling inline tags", () => {
+  test("multiple inline tags — all preserved in innerHTML", () => {
     const el = createElement("<p><strong>Bold</strong> and <code>code</code> here</p>");
-    const { t, m } = toPh(el);
-    expect(t).toBe("<0>Bold</0> and <1>code</1> here");
-    expect(m.get(0)![0]).toBe("<strong>");
-    expect(m.get(1)![0]).toBe("<code>");
+    expect(inlineOnly(el)).toBe(true);
+    const html = el.innerHTML.trim();
+    expect(html).toContain("<strong>Bold</strong>");
+    expect(html).toContain("<code>code</code>");
   });
 
   test("nested inline tags", () => {
     const el = createElement("<p><strong><code>nested</code></strong></p>");
-    const { t, m } = toPh(el);
-    expect(t).toBe("<0><1>nested</1></0>");
-    expect(m.get(0)![0]).toBe("<strong>");
-    expect(m.get(1)![0]).toBe("<code>");
+    expect(inlineOnly(el)).toBe(true);
+    expect(el.innerHTML.trim()).toBe("<strong><code>nested</code></strong>");
   });
 
-  test("<br> void tag", () => {
+  test("<br> void tag in innerHTML", () => {
     const el = createElement("<p>Line one<br>Line two</p>");
-    const { t, m } = toPh(el);
-    expect(t).toBe("Line one<0/>Line two");
-    expect(m.get(0)![1]).toBe(""); // void = no close tag
+    expect(inlineOnly(el)).toBe(true);
+    const html = el.innerHTML.trim();
+    expect(html).toMatch(/Line one<br\s*\/?>Line two/);
   });
 
   test("mixed void and paired tags", () => {
     const el = createElement("<p><strong>Bold</strong><br>Next line</p>");
-    const { t, m } = toPh(el);
-    expect(t).toBe("<0>Bold</0><1/>Next line");
-    expect(m.get(0)![0]).toBe("<strong>");
-    expect(m.get(1)![1]).toBe("");
+    expect(inlineOnly(el)).toBe(true);
+    const html = el.innerHTML.trim();
+    expect(html).toContain("<strong>Bold</strong>");
+    expect(html).toMatch(/<br\s*\/?>/);
   });
 
   test("terms page: text + strong mixed content", () => {
     const el = createElement(
       '<p>These Terms govern the <strong>tongues</strong> translation service by <strong>80x24</strong>.</p>'
     );
-    const { t, m, h } = toPh(el);
-    expect(t).toBe("These Terms govern the <0>tongues</0> translation service by <1>80x24</1>.");
-    expect(h).toBe(true);
-    expect(m.get(0)![0]).toBe("<strong>");
-    expect(m.get(1)![0]).toBe("<strong>");
+    expect(inlineOnly(el)).toBe(true);
+    const html = el.innerHTML.trim();
+    expect(html).toContain("<strong>tongues</strong>");
+    expect(html).toContain("<strong>80x24</strong>");
   });
 });
 
-// --- fromPh: restore HTML from placeholders ---
+// --- apply: innerHTML set for mixed-content ---
 
-describe("fromPh (placeholderToHtml)", () => {
-  test("single inline tag", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]]]);
-    expect(fromPh("Click <0>here</0>", m)).toBe("Click <strong>here</strong>");
+describe("apply: innerHTML for translated mixed-content", () => {
+  test("translated HTML applied via innerHTML", () => {
+    const { document } = makeDoc('<p>Visit <a href="/foo">our site</a></p>');
+    const el = document.querySelector("p")!;
+    const originalHtml = el.innerHTML;
+
+    // Simulate: collect → send innerHTML → receive translated innerHTML
+    el.setAttribute("data-t", el.innerHTML.trim());
+    el.setAttribute("data-th", originalHtml);
+    const translated = 'サイトを<a href="/foo">訪問</a>';
+    el.innerHTML = translated;
+    el.setAttribute("data-tt", translated);
+
+    expect(el.innerHTML).toBe(translated);
+    expect(el.querySelector("a")!.getAttribute("href")).toBe("/foo");
   });
 
-  test("multiple sibling tags", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]], [1, ["<code>", "</code>"]]]);
-    expect(fromPh("<0>Important</0>: use <1>tongues</1>", m))
-      .toBe("<strong>Important</strong>: use <code>tongues</code>");
+  test("plain text applied via font wrapper", () => {
+    const { document } = makeDoc("<p>Hello world</p>");
+    const el = document.querySelector("p")!;
+    el.setAttribute("data-t", "Hello world");
+    // No data-th → textContent path
+    const f = document.createElement("font");
+    f.setAttribute("data-tf", "1");
+    f.textContent = "안녕하세요 세계";
+    el.replaceChildren(f);
+
+    expect(el.textContent).toBe("안녕하세요 세계");
+  });
+});
+
+// --- undo: restore original ---
+
+describe("undo: restore original innerHTML/textContent", () => {
+  test("mixed-content restore via data-th", () => {
+    const { document } = makeDoc('<p>Visit <a href="/foo">our site</a></p>');
+    const el = document.querySelector("p")!;
+    const originalHtml = el.innerHTML;
+
+    // Apply translation
+    el.setAttribute("data-t", el.innerHTML.trim());
+    el.setAttribute("data-th", originalHtml);
+    el.innerHTML = '<a href="/foo">サイト</a>を訪問';
+    el.setAttribute("data-tt", el.innerHTML);
+
+    // Undo
+    el.innerHTML = el.getAttribute("data-th")!;
+    el.removeAttribute("data-th");
+    el.removeAttribute("data-tt");
+    el.removeAttribute("data-t");
+
+    expect(el.innerHTML).toBe(originalHtml);
   });
 
-  test("nested tags", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]], [1, ["<code>", "</code>"]]]);
-    expect(fromPh("<0><1>text</1></0>", m)).toBe("<strong><code>text</code></strong>");
+  test("plain text restore via data-t", () => {
+    const { document } = makeDoc("<p>Hello world</p>");
+    const el = document.querySelector("p")!;
+    el.setAttribute("data-t", "Hello world");
+    el.textContent = "안녕하세요 세계";
+
+    // Undo
+    el.textContent = el.getAttribute("data-t");
+    el.removeAttribute("data-t");
+
+    expect(el.textContent).toBe("Hello world");
+  });
+});
+
+// --- o === t: data-th saved even when translation matches original ---
+
+describe("o === t: data-th saved for mixed-content", () => {
+  test("data-th set when o === t and element has children", () => {
+    const { document } = makeDoc('<p>Click <a href="/help">here</a></p>');
+    const el = document.querySelector("p")!;
+    const originalHtml = el.innerHTML;
+
+    // Simulate o === t path with children
+    if (!el.hasAttribute("data-t")) {
+      el.setAttribute("data-t", el.innerHTML.trim());
+      if (el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
+    }
+
+    expect(el.hasAttribute("data-t")).toBe(true);
+    expect(el.hasAttribute("data-th")).toBe(true);
+    expect(el.getAttribute("data-th")).toBe(originalHtml);
   });
 
-  test("tag with attributes preserved", () => {
-    const m = new Map<number, PM>([[0, ['<a href="https://example.com">', "</a>"]]]);
-    expect(fromPh("Visit <0>our site</0>", m)).toBe('Visit <a href="https://example.com">our site</a>');
-  });
+  test("data-th NOT set when o === t and element has no children", () => {
+    const { document } = makeDoc("<p>plain text</p>");
+    const el = document.querySelector("p")!;
 
-  test("void tag (br)", () => {
-    const m = new Map<number, PM>([[0, ["<br>", ""]]]);
-    expect(fromPh("Line one<0/>Line two", m)).toBe("Line one<br>Line two");
-  });
+    if (!el.hasAttribute("data-t")) {
+      el.setAttribute("data-t", "plain text");
+      if (el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
+    }
 
-  test("LLM drops placeholder — graceful degradation", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]]]);
-    expect(fromPh("Click here", m)).toBe("Click here");
-  });
-
-  test("translation reorders placeholders", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]], [1, ["<code>", "</code>"]], [2, ['<a href="/docs">', "</a>"]]]);
-    expect(fromPh("Install <1>tongues</1> <2>here</2>: <0>important</0>", m))
-      .toBe('Install <code>tongues</code> <a href="/docs">here</a>: <strong>important</strong>');
-  });
-
-  test("LLM drops closing tag — cleanup removes orphan opener", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]]]);
-    expect(fromPh("<0>텍스트", m)).toBe("텍스트");
-  });
-
-  test("LLM adds space in tag — cleanup removes malformed tags", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]]]);
-    expect(fromPh("<0 >텍스트</0>", m)).toBe("텍스트");
-  });
-
-  test("LLM outputs orphan closing tag — cleanup removes it", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]]]);
-    expect(fromPh("텍스트</0>", m)).toBe("텍스트");
-  });
-
-  test("mixed: some placeholders resolve, others broken", () => {
-    const m = new Map<number, PM>([[0, ["<strong>", "</strong>"]], [1, ['<a href="/privacy">', "</a>"]]]);
-    expect(fromPh("<0>중요</0> 정보는 <1>여기에서 확인하세요", m))
-      .toBe("<strong>중요</strong> 정보는 여기에서 확인하세요");
+    expect(el.hasAttribute("data-t")).toBe(true);
+    expect(el.hasAttribute("data-th")).toBe(false);
   });
 });
 
@@ -238,181 +234,114 @@ describe("inlineOnly", () => {
   });
 });
 
-// --- Full roundtrip: toPh → translate → fromPh ---
+// --- Full roundtrip: collect innerHTML → translate → apply innerHTML ---
 
-describe("full roundtrip (toPh → translate → fromPh)", () => {
-  test("code tag survives translation", () => {
-    const el = createElement("<p>Use <code>data-tongues-ignore</code> attribute</p>");
-    const { t, m } = toPh(el);
-    const translated = t.replace("Use", "Use the").replace("attribute", "option");
-    expect(fromPh(translated, m)).toBe("Use the <code>data-tongues-ignore</code> option");
-  });
-
-  test("terms page mixed-content survives translation", () => {
-    const el = createElement(
-      '<p>These Terms govern the <strong>tongues</strong> service by <strong>80x24</strong>.</p>'
-    );
-    const { t, m } = toPh(el);
-    // Simulated Korean translation
-    const translated = "이 약관은 <1>80x24</1>의 <0>tongues</0> 서비스를 규율합니다.";
-    const html = fromPh(translated, m);
-    expect(html).toBe("이 약관은 <strong>80x24</strong>의 <strong>tongues</strong> 서비스를 규율합니다.");
-  });
-
-  test("br tag preserved through translation", () => {
-    const el = createElement("<p>첫 번째 줄<br>두 번째 줄</p>");
-    const { t, m } = toPh(el);
-    const translated = "First line<0/>Second line";
-    const html = fromPh(translated, m);
-    expect(html).toContain("First line");
-    expect(html).toContain("Second line");
-    expect(html).toMatch(/<br\s*\/?>/);
-  });
-
-  test("original innerHTML can be restored after translation", () => {
-    const { document: doc } = parseHTML(
-      '<!DOCTYPE html><html><body><p>Use <code>data-tongues-ignore</code> attribute</p></body></html>'
-    );
-    const el = doc.body.firstElementChild!;
+describe("full roundtrip (innerHTML → translate → apply)", () => {
+  test("strong tag preserved through translation", () => {
+    const { document } = makeDoc("<p>This is <strong>important</strong> text</p>");
+    const el = document.querySelector("p")!;
     const originalHtml = el.innerHTML;
 
     // Collect
-    const { t, m } = toPh(el);
-    // Apply translation
-    const translated = "Use the <0>data-tongues-ignore</0> option";
-    el.innerHTML = fromPh(translated, m);
-    expect(el.textContent).toBe("Use the data-tongues-ignore option");
+    const collected = el.innerHTML.trim();
+    expect(collected).toContain("<strong>important</strong>");
 
-    // Restore original
-    el.innerHTML = originalHtml;
+    // Apply translated
+    el.setAttribute("data-t", collected);
+    el.setAttribute("data-th", originalHtml);
+    el.innerHTML = "これは<strong>重要な</strong>テキストです";
+
+    expect(el.textContent).toBe("これは重要なテキストです");
+    expect(el.querySelector("strong")!.textContent).toBe("重要な");
+
+    // Restore
+    el.innerHTML = el.getAttribute("data-th")!;
     expect(el.innerHTML).toBe(originalHtml);
-    expect(el.textContent).toBe("Use data-tongues-ignore attribute");
   });
-});
 
-// --- Issue #92: toPh escapes literal < and > from decoded entities ---
+  test("a tag with href preserved through translation", () => {
+    const { document } = makeDoc('<p>Visit <a href="https://example.com">our site</a> now</p>');
+    const el = document.querySelector("p")!;
+    const originalHtml = el.innerHTML;
 
-describe("toPh entity escaping (#92)", () => {
-  test("&lt; and &gt; in text nodes become &lt; and &gt; in placeholder text", () => {
-    const el = createElement(
-      '<p><a href="#" id="next">&lt; newer</a> · <span id="current-date">2026-03-12 (1/18)</span> · <a href="#" id="prev">older &gt;</a></p>'
+    el.setAttribute("data-t", el.innerHTML.trim());
+    el.setAttribute("data-th", originalHtml);
+    el.innerHTML = '今すぐ<a href="https://example.com">サイト</a>を訪問';
+
+    expect(el.querySelector("a")!.getAttribute("href")).toBe("https://example.com");
+    expect(el.querySelector("a")!.textContent).toBe("サイト");
+  });
+
+  test("br tag preserved through translation", () => {
+    const { document } = makeDoc("<p>First line<br>Second line</p>");
+    const el = document.querySelector("p")!;
+    el.setAttribute("data-t", el.innerHTML.trim());
+    el.setAttribute("data-th", el.innerHTML);
+    el.innerHTML = "1行目<br>2行目";
+
+    expect(el.innerHTML).toMatch(/<br\s*\/?>/);
+    expect(el.textContent).toContain("1行目");
+    expect(el.textContent).toContain("2行目");
+  });
+
+  test("multiple inline children with different attributes", () => {
+    const { document } = makeDoc(
+      '<p><a href="/page1" class="link1">Click here</a> for <strong>info</strong></p>'
     );
-    const { t } = toPh(el);
-    // < and > from decoded entities must be escaped so they don't collide with <0>...</0> tags
-    expect(t).toContain("&lt; newer");
-    expect(t).toContain("older &gt;");
-    expect(t).not.toMatch(/(?<!&[lg]t);\s*newer/); // no raw < before newer
+    const el = document.querySelector("p")!;
+    const originalHtml = el.innerHTML;
+    const collected = el.innerHTML.trim();
+
+    expect(collected).toContain('href="/page1"');
+    expect(collected).toContain('class="link1"');
+    expect(collected).toContain("<strong>info</strong>");
+
+    el.setAttribute("data-t", collected);
+    el.setAttribute("data-th", originalHtml);
+    el.innerHTML = '<a href="/page1" class="link1">ここをクリック</a>して<strong>情報</strong>を見る';
+
+    expect(el.querySelector("a")!.getAttribute("href")).toBe("/page1");
+    expect(el.querySelector("strong")!.textContent).toBe("情報");
   });
-});
 
-// --- Issue #92 full scenario: p with multiple a/span children ---
-
-describe("issue #92 fromPh with escaped entities", () => {
-  test("restores all child elements from placeholder map with escaped < and >", () => {
-    const m = new Map<number, PM>([
-      [0, ['<a href="#" id="next" style="opacity: 0.3;">', "</a>"]],
-      [1, ['<span id="current-date">', "</span>"]],
-      [2, ['<a href="#" id="prev" style="opacity: 1;">', "</a>"]],
-      [3, ['<a href="#" id="today">', "</a>"]],
-      [4, ['<a href="#" id="random">', "</a>"]],
-    ]);
-    const translated = "<0>&lt; 新しい</0> · <1>2026-03-12 (1/18)</1> · <2>古い &gt;</2> · <3>今日</3> · <4>ランダム</4>";
-    const html = fromPh(translated, m);
-    // Must restore all child elements with attributes
-    expect(html).toContain('<a href="#" id="next"');
-    expect(html).toContain('<span id="current-date">');
-    expect(html).toContain('<a href="#" id="prev"');
-    expect(html).toContain('<a href="#" id="today">');
-    expect(html).toContain('<a href="#" id="random">');
-    // Must unescape &lt; and &gt; back to display correctly in innerHTML
-    expect(html).toContain("&lt; 新しい");
-    expect(html).toContain("古い &gt;");
-  });
-});
-
-describe("full roundtrip issue #92 scenario", () => {
-  test("p with multiple inline children: toPh → translate → fromPh preserves DOM structure", () => {
-    const el = createElement(
-      '<p><a href="#" id="next" style="opacity: 0.3;">&lt; newer</a> · <span id="current-date">2026-03-12 (1/18)</span> · <a href="#" id="prev" style="opacity: 1;">older &gt;</a> · <a href="#" id="today">today</a> · <a href="#" id="random">random</a></p>'
+  test("issue #92 scenario: p with multiple a/span children", () => {
+    const { document } = makeDoc(
+      '<p><a href="#" id="next">&lt; newer</a> · <span id="current-date">2026-03-12</span> · <a href="#" id="prev">older &gt;</a></p>'
     );
-    const { t, m } = toPh(el);
-    // Simulated translation (Japanese)
-    const translated = "<0>&lt; 新しい</0> · <1>2026-03-12 (1/18)</1> · <2>古い &gt;</2> · <3>今日</3> · <4>ランダム</4>";
-    const html = fromPh(translated, m);
-    // All 5 elements must be present with their attributes
-    expect(html).toContain('<a href="#" id="next"');
-    expect(html).toContain('<span id="current-date">');
-    expect(html).toContain('<a href="#" id="prev"');
-    expect(html).toContain('<a href="#" id="today">');
-    expect(html).toContain('<a href="#" id="random">');
-    // Content must be translated
-    expect(html).toContain("新しい");
-    expect(html).toContain("古い");
-    expect(html).toContain("今日");
-    expect(html).toContain("ランダム");
+    const el = document.querySelector("p")!;
+    const originalHtml = el.innerHTML;
+    const collected = el.innerHTML.trim();
+
+    expect(collected).toContain('id="next"');
+    expect(collected).toContain('id="current-date"');
+    expect(collected).toContain('id="prev"');
+
+    el.setAttribute("data-t", collected);
+    el.setAttribute("data-th", originalHtml);
+    el.innerHTML = '<a href="#" id="next">&lt; 新しい</a> · <span id="current-date">2026-03-12</span> · <a href="#" id="prev">古い &gt;</a>';
+
+    expect(el.querySelector("#next")!.textContent).toBe("< 新しい");
+    expect(el.querySelector("#prev")!.textContent).toBe("古い >");
+
+    // Restore
+    el.innerHTML = el.getAttribute("data-th")!;
+    expect(el.innerHTML).toBe(originalHtml);
   });
 });
 
-// --- Fix #3: phs Map key collision when same text appears in multiple elements ---
+// --- Two elements with same text but different attributes ---
 
-describe("phs element-based keying (#92 fix 3)", () => {
-  test("two elements with identical text structure get independent placeholder maps", () => {
-    // Simulate two <p> elements with the same text but different attributes on children
+describe("independent elements with same text structure", () => {
+  test("each element sends its own innerHTML with unique attributes", () => {
     const el1 = createElement('<p><a href="/page1" class="link1">Click here</a> for info</p>');
     const el2 = createElement('<p><a href="/page2" class="link2">Click here</a> for info</p>');
 
-    const r1 = toPh(el1);
-    const r2 = toPh(el2);
+    const html1 = el1.innerHTML.trim();
+    const html2 = el2.innerHTML.trim();
 
-    // Both produce the same placeholder text
-    expect(r1.t).toBe(r2.t);
-    expect(r1.t).toBe("<0>Click here</0> for info");
-
-    // But the placeholder maps should contain different opening tags
-    expect(r1.m.get(0)![0]).toContain('href="/page1"');
-    expect(r1.m.get(0)![0]).toContain('class="link1"');
-    expect(r2.m.get(0)![0]).toContain('href="/page2"');
-    expect(r2.m.get(0)![0]).toContain('class="link2"');
-
-    // With a text-keyed Map, phs.set(t, r2.m) would overwrite r1.m
-    // With element-keyed WeakMap, each element keeps its own map
-    const phs = new WeakMap<Element, Map<number, PM>>();
-    phs.set(el1, r1.m);
-    phs.set(el2, r2.m);
-
-    // Both should be independently retrievable
-    const pm1 = phs.get(el1)!;
-    const pm2 = phs.get(el2)!;
-    expect(pm1.get(0)![0]).toContain('href="/page1"');
-    expect(pm2.get(0)![0]).toContain('href="/page2"');
-
-    // Translating each should produce different HTML
-    const translated = "<0>ここをクリック</0> 情報";
-    const html1 = fromPh(translated, pm1);
-    const html2 = fromPh(translated, pm2);
+    // innerHTML is different because attributes differ
     expect(html1).toContain('href="/page1"');
-    expect(html1).toContain('class="link1"');
     expect(html2).toContain('href="/page2"');
-    expect(html2).toContain('class="link2"');
-  });
-
-  test("with old text-keyed Map, second element overwrites first (regression proof)", () => {
-    const el1 = createElement('<p><a href="/page1">Click here</a> for info</p>');
-    const el2 = createElement('<p><a href="/page2">Click here</a> for info</p>');
-
-    const r1 = toPh(el1);
-    const r2 = toPh(el2);
-
-    // Demonstrate the old bug: text-keyed Map causes overwrite
-    const oldPhs = new Map<string, Map<number, PM>>();
-    oldPhs.set(r1.t, r1.m);
-    oldPhs.set(r2.t, r2.m); // overwrites r1.m because r1.t === r2.t
-
-    // Only one entry in the Map — el1's data is lost
-    expect(oldPhs.size).toBe(1);
-    const pm = oldPhs.get(r1.t)!;
-    // pm is r2's map, not r1's
-    expect(pm.get(0)![0]).toContain('href="/page2"');
-    expect(pm.get(0)![0]).not.toContain('href="/page1"');
+    expect(html1).not.toBe(html2);
   });
 });

--- a/test/observer.test.ts
+++ b/test/observer.test.ts
@@ -48,7 +48,7 @@ describe("observer: strip markers on external content change", () => {
 
   test("strips all three markers (data-t, data-th, data-tt)", () => {
     const { document } = makeDoc(
-      `<div data-t="Click <0>here</0>" data-th="Click <b>here</b>" data-tt="<b>여기</b>를 클릭"><b>여기</b>를 클릭</div>`
+      `<div data-t="Click <b>here</b>" data-th="Click <b>here</b>" data-tt="<b>여기</b>를 클릭"><b>여기</b>를 클릭</div>`
     );
     const el = document.querySelector("div")!;
     el.innerHTML = "<b>New link</b> text";

--- a/test/phantom-tags.test.ts
+++ b/test/phantom-tags.test.ts
@@ -1,173 +1,124 @@
 import { describe, test, expect } from "bun:test";
 
 /**
- * Unit tests for phantom placeholder tag stripping.
- * Replicates stripPhantomTags() from translator.ts to verify
- * that LLM-hallucinated tags are removed from translations
- * when the original text had no placeholder tags.
- *
- * Bug: https://github.com/80x24/tongues/issues/75
- * When docs page is in Korean, Claude sometimes adds <0>...</0> tags
- * to translations of plain text (no inline HTML), causing literal
- * "<0>...</0>" to appear in the UI.
+ * Unit tests for phantom HTML tag stripping.
+ * Replicates stripPhantomHtml() from translator.ts:
+ * if original has no `<`, strip any HTML the LLM hallucinated.
  */
 
-// --- Replicate from translator.ts ---
-
-const PH_TAG_RE = /<\/?(\d+)\s*\/?>/;
-
-function stripPhantomTags(original: string, translated: string): string {
-  if (PH_TAG_RE.test(original)) return translated;
-  return translated.replace(/<\/?(\d+)\s*\/?>/g, "");
+function stripPhantomHtml(original: string, translated: string): string {
+  if (original.includes("<")) return translated;
+  return translated.replace(/<[^>]+>/g, "");
 }
 
-// --- Tests ---
-
-describe("stripPhantomTags", () => {
-  describe("plain text originals (no tags) — phantom tags MUST be stripped", () => {
-    test("strips wrapping <0>...</0> phantom tag (exact bug from #75)", () => {
+describe("stripPhantomHtml", () => {
+  describe("plain text originals (no <) — phantom HTML MUST be stripped", () => {
+    test("strips wrapping <strong>...</strong> phantom tag", () => {
       const original = 'Read-only. Current translation locale (e.g. "en", "ja").';
-      const translated = '<0>읽기 전용입니다. 현재 번역 언어입니다 (예: "en", "ja").</0>';
-      expect(stripPhantomTags(original, translated))
+      const translated = '<strong>읽기 전용입니다.</strong> 현재 번역 언어입니다 (예: "en", "ja").';
+      expect(stripPhantomHtml(original, translated))
         .toBe('읽기 전용입니다. 현재 번역 언어입니다 (예: "en", "ja").');
     });
 
-    test("strips phantom <0>...</0> around full sentence", () => {
+    test("strips phantom <em> around full sentence", () => {
       const original = "Switch to a specific language. Returns a Promise.";
-      const translated = "<0>특정 언어로 전환합니다. Promise를 반환합니다.</0>";
-      expect(stripPhantomTags(original, translated))
+      const translated = "<em>특정 언어로 전환합니다. Promise를 반환합니다.</em>";
+      expect(stripPhantomHtml(original, translated))
         .toBe("특정 언어로 전환합니다. Promise를 반환합니다.");
     });
 
     test("strips multiple phantom tags in same translation", () => {
       const original = "Revert to original text.";
-      const translated = "<0>원본 텍스트로</0> <1>되돌립니다.</1>";
-      expect(stripPhantomTags(original, translated))
+      const translated = "<strong>원본 텍스트로</strong> <em>되돌립니다.</em>";
+      expect(stripPhantomHtml(original, translated))
         .toBe("원본 텍스트로 되돌립니다.");
     });
 
-    test("strips phantom self-closing tag <0/>", () => {
+    test("strips phantom <br> tag", () => {
       const original = "Hello world";
-      const translated = "안녕하세요<0/> 세계";
-      expect(stripPhantomTags(original, translated))
+      const translated = "안녕하세요<br> 세계";
+      expect(stripPhantomHtml(original, translated))
         .toBe("안녕하세요 세계");
     });
 
-    test("strips orphaned opening tag", () => {
-      const original = "Simple text";
-      const translated = "<0>간단한 텍스트";
-      expect(stripPhantomTags(original, translated))
-        .toBe("간단한 텍스트");
-    });
-
-    test("strips orphaned closing tag", () => {
-      const original = "Simple text";
-      const translated = "간단한 텍스트</0>";
-      expect(stripPhantomTags(original, translated))
-        .toBe("간단한 텍스트");
+    test("strips phantom <a> with attributes", () => {
+      const original = "Click here for help";
+      const translated = '<a href="/help">도움말은 여기를 클릭하세요</a>';
+      expect(stripPhantomHtml(original, translated))
+        .toBe("도움말은 여기를 클릭하세요");
     });
 
     test("handles translation with no phantom tags (no-op)", () => {
       const original = "Hello world";
       const translated = "안녕하세요 세계";
-      expect(stripPhantomTags(original, translated))
+      expect(stripPhantomHtml(original, translated))
         .toBe("안녕하세요 세계");
     });
 
     test("handles empty translation", () => {
       const original = "Hello";
       const translated = "";
-      expect(stripPhantomTags(original, translated)).toBe("");
-    });
-
-    test("strips higher-numbered phantom tags", () => {
-      const original = "Client script version";
-      const translated = "<5>클라이언트 스크립트 버전</5>";
-      expect(stripPhantomTags(original, translated))
-        .toBe("클라이언트 스크립트 버전");
-    });
-
-    test("strips phantom tags with spaces (malformed)", () => {
-      const original = "Some text";
-      const translated = "<0 >텍스트</0 >";
-      // The regex handles optional whitespace before closing >
-      expect(stripPhantomTags(original, translated))
-        .toBe("텍스트");
+      expect(stripPhantomHtml(original, translated)).toBe("");
     });
   });
 
-  describe("text with real tags — MUST preserve them", () => {
-    test("preserves <0>...</0> when original has it", () => {
-      const original = "<0>Email address:</0> Provided during registration.";
-      const translated = "<0>メールアドレス：</0> 登録時に提供されます。";
-      expect(stripPhantomTags(original, translated))
-        .toBe("<0>メールアドレス：</0> 登録時に提供されます。");
+  describe("text with real HTML tags — MUST preserve them", () => {
+    test("preserves <strong> when original has it", () => {
+      const original = "This is <strong>important</strong> text";
+      const translated = "これは<strong>重要な</strong>テキストです";
+      expect(stripPhantomHtml(original, translated))
+        .toBe("これは<strong>重要な</strong>テキストです");
     });
 
-    test("preserves multiple tags when original has them", () => {
-      const original = "<0>Bold</0> and <1>code</1> here";
-      const translated = "<0>太字</0> と <1>コード</1> ここ";
-      expect(stripPhantomTags(original, translated))
-        .toBe("<0>太字</0> と <1>コード</1> ここ");
+    test("preserves <a> with href when original has it", () => {
+      const original = 'Visit <a href="/docs">docs</a> page';
+      const translated = '<a href="/docs">ドキュメント</a>ページを見る';
+      expect(stripPhantomHtml(original, translated))
+        .toBe('<a href="/docs">ドキュメント</a>ページを見る');
     });
 
-    test("preserves self-closing tag when original has it", () => {
-      const original = "Line one<0/>Line two";
-      const translated = "1行目<0/>2行目";
-      expect(stripPhantomTags(original, translated))
-        .toBe("1行目<0/>2行目");
+    test("preserves <br> when original has it", () => {
+      const original = "Line one<br>Line two";
+      const translated = "1行目<br>2行目";
+      expect(stripPhantomHtml(original, translated))
+        .toBe("1行目<br>2行目");
     });
 
-    test("preserves tags even when LLM reorders them", () => {
-      const original = "<0>First</0> then <1>second</1>";
-      const translated = "<1>두 번째</1> 그리고 <0>첫 번째</0>";
-      expect(stripPhantomTags(original, translated))
-        .toBe("<1>두 번째</1> 그리고 <0>첫 번째</0>");
+    test("preserves multiple tags when original has HTML", () => {
+      const original = "<strong>Bold</strong> and <code>code</code> here";
+      const translated = "<strong>太字</strong> と <code>コード</code> ここ";
+      expect(stripPhantomHtml(original, translated))
+        .toBe("<strong>太字</strong> と <code>コード</code> ここ");
     });
   });
 
   describe("edge cases", () => {
-    test("text with angle brackets that are NOT placeholder tags", () => {
+    test("text with angle brackets that look like HTML but aren't tags", () => {
       const original = "Use array[0] for the first element";
       const translated = "최초 요소에 array[0] 사용";
-      expect(stripPhantomTags(original, translated))
+      expect(stripPhantomHtml(original, translated))
         .toBe("최초 요소에 array[0] 사용");
-    });
-
-    test("text with code examples mentioning tags", () => {
-      // This text has NO actual placeholder tags (no <0>, </0> etc.)
-      const original = 'Use translate="no" to exclude elements';
-      const translated = '<0>요소를 제외하려면 translate="no"를 사용하세요</0>';
-      expect(stripPhantomTags(original, translated))
-        .toBe('요소를 제외하려면 translate="no"를 사용하세요');
     });
 
     test("other locales: Japanese with phantom tags", () => {
       const original = "Read-only. Current translation locale.";
-      const translated = "<0>読み取り専用。現在の翻訳ロケール。</0>";
-      expect(stripPhantomTags(original, translated))
+      const translated = "<strong>読み取り専用。現在の翻訳ロケール。</strong>";
+      expect(stripPhantomHtml(original, translated))
         .toBe("読み取り専用。現在の翻訳ロケール。");
     });
 
     test("other locales: Chinese with phantom tags", () => {
       const original = "Switch to a specific language.";
-      const translated = "<0>切换到指定语言。</0>";
-      expect(stripPhantomTags(original, translated))
+      const translated = "<em>切换到指定语言。</em>";
+      expect(stripPhantomHtml(original, translated))
         .toBe("切换到指定语言。");
     });
 
-    test("other locales: Spanish with phantom tags", () => {
-      const original = "Read-only. Current translation locale.";
-      const translated = "<0>Solo lectura. Configuración regional de traducción actual.</0>";
-      expect(stripPhantomTags(original, translated))
-        .toBe("Solo lectura. Configuración regional de traducción actual.");
-    });
-
-    test("double-digit phantom tags", () => {
-      const original = "Plain text without tags";
-      const translated = "<10>태그 없는 일반 텍스트</10>";
-      expect(stripPhantomTags(original, translated))
-        .toBe("태그 없는 일반 텍스트");
+    test("self-closing tags stripped from plain text", () => {
+      const original = "Plain text";
+      const translated = "일반 텍스트<br/>";
+      expect(stripPhantomHtml(original, translated))
+        .toBe("일반 텍스트");
     });
   });
 });


### PR DESCRIPTION
## Summary

- **`<0>...</0>` 번호 태그 시스템 완전 제거** — 5번 이상 버그 원인이었던 placeholder 방식 폐기
- mixed-content 요소의 `innerHTML`을 그대로 LLM에 전송, Claude가 HTML 태그+속성 보존하고 텍스트만 번역
- `o === t` 케이스에서 `data-th` 미저장 → undo() DOM 파괴 버그 수정

### 삭제된 코드
`toPh`, `fromPh`, `esc`, `phs` WeakMap, `PM` 타입, `stripPhantomTags`, `fixPlaceholderTags`, `PH_TAG_RE`, `WORD_TO_DIGIT`, `TAG_FIX_RE`

### 추가된 안전장치
`stripPhantomHtml`: original에 `<`가 없는데 translation에 HTML 태그 있으면 strip

## Test plan

- [x] `bun run build` 성공
- [x] `bun test` 128개 전체 통과 (0 fail)
- [x] tongues `/test` 페이지 수동 테스트: 단순 텍스트, `<strong>`, `<a>`, 언어 변경
- [x] menupie section nav `<span class="section-nav-label">` 보존 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)