### PR TITLE
fix: pulse animation renders before API call

### DIFF
--- a/src/client/t.ts
+++ b/src/client/t.ts
@@ -143,13 +143,13 @@ async function translate(inc = false, root?: Element) {
   const { txt, atr } = collect(inc, root), all = [...new Set([...txt.keys(), ...atr.keys()])];
   if (!all.length) { busy = false; return; }
   for (const els of txt.values()) for (const el of els) el.classList.add("t-ing");
-  const pulseStart = Date.now();
+  // Yield to browser so pulse animation renders before any fetch/apply
+  await new Promise(w => requestAnimationFrame(() => setTimeout(w, 0)));
   const cached = lg(), hit = new Map<string, string>(), miss: string[] = [];
   for (const t of all) { const v = cached.get(t); if (v !== undefined) hit.set(t, v); else miss.push(t); }
   if (hit.size) {
     // Ensure pulse is visible for at least 300ms even on cache hit
-    const elapsed = Date.now() - pulseStart;
-    if (elapsed < 300) await new Promise(w => setTimeout(w, 300 - elapsed));
+    await new Promise(w => setTimeout(w, 300));
     apply(txt, atr, hit);
   }
   if (miss.length) {


### PR DESCRIPTION
## Summary
- `.t-ing` 클래스 추가 후 동기 코드가 이어져서 브라우저가 렌더링할 기회가 없었음
- `requestAnimationFrame` + `setTimeout(0)` yield 추가로 pulse가 먼저 렌더링됨
- 캐시 히트 시 300ms 고정 대기 (Date.now 비교 대신 단순화)

## Test plan
- [x] 128 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)