### PR TITLE
fix: eliminate intermediate language flash on setLocale switch

### DIFF
--- a/src/client/t.ts
+++ b/src/client/t.ts
@@ -42,10 +42,7 @@ function collect(inc: boolean, root?: Element) {
     if (SK.has(el.tagName) || (nt && nt !== root)) return 2;
     if ((el as HTMLElement).isContentEditable) return 2;
     if (el.parentElement && hd.has(el.parentElement)) return 3;
-    if (inc && el.hasAttribute("data-t")) {
-      if (!el.hasAttribute("data-th")) return 2;
-      if (el.innerHTML === el.getAttribute("data-th") || el.innerHTML === el.getAttribute("data-tt")) return 2;
-    }
+    if (inc && el.hasAttribute("data-th")) return 2;
     const t = el.textContent?.trim();
     if (!t || t.length < 2) return 3;
     if (el.children.length > 0) {
@@ -60,7 +57,9 @@ function collect(inc: boolean, root?: Element) {
   let n: Node | null;
   while ((n = tw.nextNode())) {
     const el = n as Element; let t: string;
-    if (hd.has(el)) t = el.innerHTML.trim();
+    const orig = el.getAttribute("data-th");
+    if (orig) t = orig.trim();
+    else if (hd.has(el)) t = el.innerHTML.trim();
     else t = el.textContent!.trim();
     if (t && t.length >= 2) { const a = txt.get(t) || []; a.push(el); txt.set(t, a); }
   }
@@ -68,8 +67,9 @@ function collect(inc: boolean, root?: Element) {
   for (const el of atRoot.querySelectorAll("[placeholder],[title],[alt],[aria-label]")) {
     const ant = el.closest(NT);
     if ((ant && ant !== root) || (el as HTMLElement).isContentEditable || SK.has(el.tagName)) continue;
-    for (const a of AT) { const v = el.getAttribute(a)?.trim();
-      if (!v || v.length < 2 || (inc && el.hasAttribute(`data-ta-${a}`))) continue;
+    for (const a of AT) { const origAttr = el.getAttribute(`data-ta-${a}`);
+      const v = (origAttr || el.getAttribute(a))?.trim();
+      if (!v || v.length < 2 || (inc && origAttr)) continue;
       const arr = atr.get(v) || []; arr.push({ e: el, a }); atr.set(v, arr); }
   }
   return { txt, atr };
@@ -90,10 +90,7 @@ function apply(tE: Map<string, Element[]>, aE: Map<string, { e: Element; a: stri
   ps(); try { for (const [o, t] of tr) {
     if (o === t) {
       for (const el of tE.get(o) || []) {
-        if (!el.hasAttribute("data-t")) {
-          el.setAttribute("data-t", o);
-          if (el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
-        }
+        if (!el.hasAttribute("data-th")) el.setAttribute("data-th", el.innerHTML);
         el.classList.remove("t-ing");
       }
       for (const { e, a } of aE.get(o) || []) if (!e.hasAttribute(`data-ta-${a}`)) e.setAttribute(`data-ta-${a}`, o);
@@ -101,15 +98,8 @@ function apply(tE: Map<string, Element[]>, aE: Map<string, { e: Element; a: stri
     }
     const els = tE.get(o);
     if (els) { for (const el of els) {
-      if (!el.hasAttribute("data-t")) {
-        el.setAttribute("data-t", o);
-        if (el.hasAttribute("data-th") || el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
-      }
-      if (el.hasAttribute("data-th")) {
-        el.innerHTML = t; el.setAttribute("data-tt", t);
-      } else {
-        const f = document.createElement("font"); f.setAttribute("data-tf", "1"); f.textContent = t; el.replaceChildren(f);
-      }
+      if (!el.hasAttribute("data-th")) el.setAttribute("data-th", el.innerHTML);
+      el.innerHTML = t;
       fi(el);
     } }
     for (const { e, a } of aE.get(o) || []) { if (!e.hasAttribute(`data-ta-${a}`)) e.setAttribute(`data-ta-${a}`, o); e.setAttribute(a, t); }
@@ -119,8 +109,7 @@ function apply(tE: Map<string, Element[]>, aE: Map<string, { e: Element; a: stri
 function undo() {
   ps(); try {
     $(".t-ing").forEach(el => { el.classList.remove("t-ing"); const s = (el as HTMLElement).style; s.opacity = ""; s.transition = ""; });
-    $("[data-th]").forEach(el => { el.innerHTML = el.getAttribute("data-th")!; el.removeAttribute("data-th"); el.removeAttribute("data-tt"); el.removeAttribute("data-t"); });
-    $("[data-t]").forEach(el => { el.textContent = el.getAttribute("data-t"); el.removeAttribute("data-t"); });
+    $("[data-th]").forEach(el => { el.innerHTML = el.getAttribute("data-th")!; el.removeAttribute("data-th"); });
     for (const a of AT) { const k = `data-ta-${a}`; $(`[${k}]`).forEach(el => { el.setAttribute(a, el.getAttribute(k)!); el.removeAttribute(k); }); }
   } finally { rs(); }
 }
@@ -139,7 +128,7 @@ function ls(tr: Map<string, string>) {
 
 async function translate(inc = false, root?: Element) {
   if (busy) return; busy = true;
-  if (!inc && !root) { undo(); done = false; }
+  if (!inc && !root) { done = false; }
   const { txt, atr } = collect(inc, root), all = [...new Set([...txt.keys(), ...atr.keys()])];
   if (!all.length) { busy = false; return; }
   for (const els of txt.values()) for (const el of els) el.classList.add("t-ing");
@@ -174,7 +163,7 @@ function observe() {
     for (const m of muts) { const el = m.target instanceof Element ? m.target : m.target.parentElement;
       if (!el || (el as HTMLElement).isContentEditable) continue;
       if (el.closest(NT)) continue;
-      if (el.hasAttribute("data-t")) { el.removeAttribute("data-t"); el.removeAttribute("data-th"); el.removeAttribute("data-tt"); }
+      if (el.hasAttribute("data-th")) { el.removeAttribute("data-th"); }
       dirty = true; }
     if (dirty) { if (tm) clearTimeout(tm);
       tm = setTimeout(() => { if (!busy) translate(done); else queued = true; }, 300); }

--- a/test/inline-tags.test.ts
+++ b/test/inline-tags.test.ts
@@ -101,25 +101,19 @@ describe("apply: innerHTML for translated mixed-content", () => {
     const originalHtml = el.innerHTML;
 
     // Simulate: collect → send innerHTML → receive translated innerHTML
-    el.setAttribute("data-t", el.innerHTML.trim());
     el.setAttribute("data-th", originalHtml);
     const translated = 'サイトを<a href="/foo">訪問</a>';
     el.innerHTML = translated;
-    el.setAttribute("data-tt", translated);
 
     expect(el.innerHTML).toBe(translated);
     expect(el.querySelector("a")!.getAttribute("href")).toBe("/foo");
   });
 
-  test("plain text applied via font wrapper", () => {
+  test("plain text applied via innerHTML", () => {
     const { document } = makeDoc("<p>Hello world</p>");
     const el = document.querySelector("p")!;
-    el.setAttribute("data-t", "Hello world");
-    // No data-th → textContent path
-    const f = document.createElement("font");
-    f.setAttribute("data-tf", "1");
-    f.textContent = "안녕하세요 세계";
-    el.replaceChildren(f);
+    el.setAttribute("data-th", el.innerHTML);
+    el.innerHTML = "안녕하세요 세계";
 
     expect(el.textContent).toBe("안녕하세요 세계");
   });
@@ -134,29 +128,25 @@ describe("undo: restore original innerHTML/textContent", () => {
     const originalHtml = el.innerHTML;
 
     // Apply translation
-    el.setAttribute("data-t", el.innerHTML.trim());
     el.setAttribute("data-th", originalHtml);
     el.innerHTML = '<a href="/foo">サイト</a>を訪問';
-    el.setAttribute("data-tt", el.innerHTML);
 
     // Undo
     el.innerHTML = el.getAttribute("data-th")!;
     el.removeAttribute("data-th");
-    el.removeAttribute("data-tt");
-    el.removeAttribute("data-t");
 
     expect(el.innerHTML).toBe(originalHtml);
   });
 
-  test("plain text restore via data-t", () => {
+  test("plain text restore via data-th", () => {
     const { document } = makeDoc("<p>Hello world</p>");
     const el = document.querySelector("p")!;
-    el.setAttribute("data-t", "Hello world");
-    el.textContent = "안녕하세요 세계";
+    el.setAttribute("data-th", el.innerHTML);
+    el.innerHTML = "안녕하세요 세계";
 
     // Undo
-    el.textContent = el.getAttribute("data-t");
-    el.removeAttribute("data-t");
+    el.innerHTML = el.getAttribute("data-th")!;
+    el.removeAttribute("data-th");
 
     expect(el.textContent).toBe("Hello world");
   });
@@ -170,28 +160,22 @@ describe("o === t: data-th saved for mixed-content", () => {
     const el = document.querySelector("p")!;
     const originalHtml = el.innerHTML;
 
-    // Simulate o === t path with children
-    if (!el.hasAttribute("data-t")) {
-      el.setAttribute("data-t", el.innerHTML.trim());
-      if (el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
-    }
+    // Simulate o === t path: always set data-th
+    if (!el.hasAttribute("data-th")) el.setAttribute("data-th", el.innerHTML);
 
-    expect(el.hasAttribute("data-t")).toBe(true);
     expect(el.hasAttribute("data-th")).toBe(true);
     expect(el.getAttribute("data-th")).toBe(originalHtml);
   });
 
-  test("data-th NOT set when o === t and element has no children", () => {
+  test("data-th set when o === t and element has no children", () => {
     const { document } = makeDoc("<p>plain text</p>");
     const el = document.querySelector("p")!;
 
-    if (!el.hasAttribute("data-t")) {
-      el.setAttribute("data-t", "plain text");
-      if (el.children.length > 0) el.setAttribute("data-th", el.innerHTML);
-    }
+    // Now data-th is always set (unified approach)
+    if (!el.hasAttribute("data-th")) el.setAttribute("data-th", el.innerHTML);
 
-    expect(el.hasAttribute("data-t")).toBe(true);
-    expect(el.hasAttribute("data-th")).toBe(false);
+    expect(el.hasAttribute("data-th")).toBe(true);
+    expect(el.getAttribute("data-th")).toBe("plain text");
   });
 });
 
@@ -247,7 +231,6 @@ describe("full roundtrip (innerHTML → translate → apply)", () => {
     expect(collected).toContain("<strong>important</strong>");
 
     // Apply translated
-    el.setAttribute("data-t", collected);
     el.setAttribute("data-th", originalHtml);
     el.innerHTML = "これは<strong>重要な</strong>テキストです";
 
@@ -264,7 +247,6 @@ describe("full roundtrip (innerHTML → translate → apply)", () => {
     const el = document.querySelector("p")!;
     const originalHtml = el.innerHTML;
 
-    el.setAttribute("data-t", el.innerHTML.trim());
     el.setAttribute("data-th", originalHtml);
     el.innerHTML = '今すぐ<a href="https://example.com">サイト</a>を訪問';
 
@@ -275,7 +257,6 @@ describe("full roundtrip (innerHTML → translate → apply)", () => {
   test("br tag preserved through translation", () => {
     const { document } = makeDoc("<p>First line<br>Second line</p>");
     const el = document.querySelector("p")!;
-    el.setAttribute("data-t", el.innerHTML.trim());
     el.setAttribute("data-th", el.innerHTML);
     el.innerHTML = "1行目<br>2行目";
 
@@ -296,7 +277,6 @@ describe("full roundtrip (innerHTML → translate → apply)", () => {
     expect(collected).toContain('class="link1"');
     expect(collected).toContain("<strong>info</strong>");
 
-    el.setAttribute("data-t", collected);
     el.setAttribute("data-th", originalHtml);
     el.innerHTML = '<a href="/page1" class="link1">ここをクリック</a>して<strong>情報</strong>を見る';
 
@@ -316,7 +296,6 @@ describe("full roundtrip (innerHTML → translate → apply)", () => {
     expect(collected).toContain('id="current-date"');
     expect(collected).toContain('id="prev"');
 
-    el.setAttribute("data-t", collected);
     el.setAttribute("data-th", originalHtml);
     el.innerHTML = '<a href="#" id="next">&lt; 新しい</a> · <span id="current-date">2026-03-12</span> · <a href="#" id="prev">古い &gt;</a>';
 

--- a/test/observer.test.ts
+++ b/test/observer.test.ts
@@ -5,11 +5,11 @@ import { describe, test, expect } from "bun:test";
  *
  * Bug: https://github.com/80x24/open-tongues/issues/4
  * When JS dynamically replaces content (e.g. "loading..." → real data),
- * tongues' MutationObserver must strip data-t/data-th/data-tt markers
+ * tongues' MutationObserver must strip data-th marker
  * so the new content gets collected and re-translated.
  *
- * Fix: observer unconditionally strips markers on any mutation targeting
- * a data-t element. tongues' own changes don't trigger this because
+ * Fix: observer unconditionally strips data-th on any mutation targeting
+ * a translated element. tongues' own changes don't trigger this because
  * ps()/rs() disconnect the observer during apply().
  */
 
@@ -19,10 +19,8 @@ const { parseHTML } = require("linkedom");
 
 /** What the observer does when it sees a mutation on a translated element */
 function observerHandle(el: Element) {
-  if (el.hasAttribute("data-t")) {
-    el.removeAttribute("data-t");
+  if (el.hasAttribute("data-th")) {
     el.removeAttribute("data-th");
-    el.removeAttribute("data-tt");
   }
 }
 
@@ -35,30 +33,28 @@ function makeDoc(html: string) {
 // --- Tests ---
 
 describe("observer: strip markers on external content change", () => {
-  test("strips data-t when content is replaced", () => {
-    const { document } = makeDoc(`<div data-t="loading...">loading...</div>`);
+  test("strips data-th when content is replaced", () => {
+    const { document } = makeDoc(`<div data-th="loading...">번역된 텍스트</div>`);
     const el = document.querySelector("div")!;
     // Simulate external JS replacing content
     el.textContent = "Real content loaded";
     // Observer fires → handle
     observerHandle(el);
-    expect(el.hasAttribute("data-t")).toBe(false);
+    expect(el.hasAttribute("data-th")).toBe(false);
     expect(el.textContent).toBe("Real content loaded");
   });
 
-  test("strips all three markers (data-t, data-th, data-tt)", () => {
+  test("strips data-th on HTML element", () => {
     const { document } = makeDoc(
-      `<div data-t="Click <b>here</b>" data-th="Click <b>here</b>" data-tt="<b>여기</b>를 클릭"><b>여기</b>를 클릭</div>`
+      `<div data-th="Click <b>here</b>"><b>여기</b>를 클릭</div>`
     );
     const el = document.querySelector("div")!;
     el.innerHTML = "<b>New link</b> text";
     observerHandle(el);
-    expect(el.hasAttribute("data-t")).toBe(false);
     expect(el.hasAttribute("data-th")).toBe(false);
-    expect(el.hasAttribute("data-tt")).toBe(false);
   });
 
-  test("no-op on element without data-t", () => {
+  test("no-op on element without data-th", () => {
     const { document } = makeDoc(`<div>clean element</div>`);
     const el = document.querySelector("div")!;
     observerHandle(el); // should not throw
@@ -67,14 +63,13 @@ describe("observer: strip markers on external content change", () => {
 
   test("80x24.ai/now: loading... replaced by async PR list", () => {
     const { document } = makeDoc(
-      `<div data-t="loading..." data-tt="로딩 중..."><font data-tf="1">로딩 중...</font></div>`
+      `<div data-th="loading...">로딩 중...</div>`
     );
     const el = document.querySelector("div")!;
     // SPA async fetch replaces content entirely
     el.innerHTML = "<ul><li>menupie #69 — fix auth flow</li><li>tongues #12 — rate limit</li></ul>";
     observerHandle(el);
-    expect(el.hasAttribute("data-t")).toBe(false);
-    expect(el.hasAttribute("data-tt")).toBe(false);
+    expect(el.hasAttribute("data-th")).toBe(false);
     expect(el.textContent).toContain("menupie #69");
   });
 });
@@ -82,42 +77,41 @@ describe("observer: strip markers on external content change", () => {
 describe("observer: collect() picks up cleared elements", () => {
   // After markers are stripped, incremental collect should find the element again
 
-  test("element without data-t is eligible for incremental collect", () => {
+  test("element without data-th is eligible for incremental collect", () => {
     const { document } = makeDoc(`<div>New content here</div>`);
     const el = document.querySelector("div")!;
-    // No data-t → collect(inc=true) should process it (not skip)
-    expect(el.hasAttribute("data-t")).toBe(false);
+    // No data-th → collect(inc=true) should process it (not skip)
+    expect(el.hasAttribute("data-th")).toBe(false);
     expect(el.textContent!.trim().length).toBeGreaterThanOrEqual(2);
   });
 
-  test("element with data-t is skipped by incremental collect (no data-th)", () => {
-    const { document } = makeDoc(`<div data-t="old">translated</div>`);
+  test("element with data-th is skipped by incremental collect", () => {
+    const { document } = makeDoc(`<div data-th="original">translated</div>`);
     const el = document.querySelector("div")!;
-    // Simulates: inc && el.hasAttribute("data-t") && !el.hasAttribute("data-th") → skip
-    expect(el.hasAttribute("data-t")).toBe(true);
-    expect(el.hasAttribute("data-th")).toBe(false);
+    // Simulates: inc && el.hasAttribute("data-th") → skip
+    expect(el.hasAttribute("data-th")).toBe(true);
     // → would return NodeFilter.FILTER_REJECT (2) in collect()
   });
 
   test("after strip, element becomes eligible again", () => {
-    const { document } = makeDoc(`<div data-t="loading...">Real data</div>`);
+    const { document } = makeDoc(`<div data-th="loading...">Real data</div>`);
     const el = document.querySelector("div")!;
-    expect(el.hasAttribute("data-t")).toBe(true);
+    expect(el.hasAttribute("data-th")).toBe(true);
     observerHandle(el);
-    expect(el.hasAttribute("data-t")).toBe(false);
+    expect(el.hasAttribute("data-th")).toBe(false);
     // Now collect(inc=true) will process this element
   });
 });
 
 describe("observer: attribute translation markers (data-ta-*)", () => {
-  test("data-ta-placeholder preserved (observer only strips data-t/th/tt)", () => {
+  test("data-ta-placeholder preserved (observer only strips data-th)", () => {
     const { document } = makeDoc(
-      `<input placeholder="검색..." data-ta-placeholder="Search..." data-t="foo" />`
+      `<input placeholder="검색..." data-ta-placeholder="Search..." data-th="foo" />`
     );
     const el = document.querySelector("input")!;
     observerHandle(el);
-    // data-t stripped
-    expect(el.hasAttribute("data-t")).toBe(false);
+    // data-th stripped
+    expect(el.hasAttribute("data-th")).toBe(false);
     // data-ta-placeholder is NOT stripped by observer (attribute translations are independent)
     expect(el.getAttribute("data-ta-placeholder")).toBe("Search...");
   });
@@ -125,36 +119,36 @@ describe("observer: attribute translation markers (data-ta-*)", () => {
 
 describe("edge cases", () => {
   test("rapid replacement: content changes twice before re-translate", () => {
-    const { document } = makeDoc(`<div data-t="loading...">loading...</div>`);
+    const { document } = makeDoc(`<div data-th="loading...">번역됨</div>`);
     const el = document.querySelector("div")!;
     // First async update
     el.textContent = "Partial data...";
     observerHandle(el);
-    expect(el.hasAttribute("data-t")).toBe(false);
+    expect(el.hasAttribute("data-th")).toBe(false);
 
     // Suppose tongues hasn't re-translated yet, second update arrives
     el.textContent = "Final complete data";
-    observerHandle(el); // still no data-t, so no-op — correct
-    expect(el.hasAttribute("data-t")).toBe(false);
+    observerHandle(el); // still no data-th, so no-op — correct
+    expect(el.hasAttribute("data-th")).toBe(false);
     expect(el.textContent).toBe("Final complete data");
   });
 
   test("element emptied then filled (skeleton pattern)", () => {
-    const { document } = makeDoc(`<div data-t="Loading items">Loading items</div>`);
+    const { document } = makeDoc(`<div data-th="Loading items">번역된 항목</div>`);
     const el = document.querySelector("div")!;
     // Framework clears content first
     el.textContent = "";
     observerHandle(el);
-    expect(el.hasAttribute("data-t")).toBe(false);
+    expect(el.hasAttribute("data-th")).toBe(false);
     // Then fills with real content
     el.textContent = "3 items found";
-    observerHandle(el); // no-op (no data-t)
+    observerHandle(el); // no-op (no data-th)
     expect(el.textContent).toBe("3 items found");
   });
 
   test("notranslate elements are not affected", () => {
     const { document } = makeDoc(
-      `<div class="notranslate" data-t="code">translated code</div>`
+      `<div class="notranslate" data-th="code">translated code</div>`
     );
     const el = document.querySelector("div")!;
     // In real observer, el.closest(NT) would match → skip entirely
@@ -164,10 +158,10 @@ describe("edge cases", () => {
   });
 
   test("contentEditable elements are skipped", () => {
-    const { document } = makeDoc(`<div contenteditable="true" data-t="editable">user typing</div>`);
+    const { document } = makeDoc(`<div contenteditable="true" data-th="editable">user typing</div>`);
     const el = document.querySelector("div")!;
     // In real observer, isContentEditable check → continue (skip)
     expect(el.getAttribute("contenteditable")).toBe("true");
-    // data-t should NOT be stripped for contentEditable (observer skips before reaching observerHandle)
+    // data-th should NOT be stripped for contentEditable (observer skips before reaching observerHandle)
   });
 });


### PR DESCRIPTION
## Summary
- **Bug fix**: `setLocale("ko")` → `setLocale("en")` 시 원본(ja)이 잠깐 보이던 문제 해결. `undo()` 대신 `data-th`에서 원본을 읽어 API 요청, 이전 번역이 화면에 유지된 채 새 번역으로 직접 교체
- **속성 통합**: `data-t` + `data-th` + `data-tt` → `data-th` 하나로. `<font data-tf>` 래퍼도 제거

## Test plan
- [x] `bun test` 128 pass, 0 fail
- [ ] tongues.80x24.ai/test 에서 sLocale=ja, ko→en 전환 시 ja 중간 노출 없는지 확인
- [ ] restore() 정상 동작 확인
- [ ] incremental 번역 (DOM 동적 추가) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)