### PR TITLE
docs: add translateEl({ to }) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,34 @@ Health check with cache statistics.
 
 ### Client API (`window.t`)
 
-- `t.setLocale("ko")` — translate to a language
+- `t.setLocale("ko")` — translate the page to a language
 - `t.restore()` — revert to original text
-- `t.translateEl(".selector")` — translate specific elements
+- `t.translateEl(target)` — translate specific elements (bypasses root's `translate="no"`)
+- `t.translateEl(target, { to: "ko" })` — translate specific elements to a locale without changing global state
 - `t.locale` — current locale (read-only)
+- `t.sourceLocale` — source language (read-only)
+
+### Scoped Translation
+
+Use `translateEl` with `{ to }` to translate specific sections independently — no `setLocale` needed:
+
+```html
+<nav>UI stays in original language</nav>
+<main translate="no">Content translated on demand</main>
+```
+
+```js
+// Translate only the content area to Korean
+await t.translateEl("main", { to: "ko" });
+
+// Switch to English — only main changes, UI untouched
+await t.translateEl("main", { to: "en" });
+
+// Restore to original — no API call
+await t.translateEl("main", { to: t.sourceLocale });
+```
+
+This is useful when you want to translate content independently from UI, or when different sections need different languages.
 
 ### Exclude from translation
 


### PR DESCRIPTION
## Summary
- Client API 섹션에 `translateEl(target, { to })` 옵션 문서화
- Scoped Translation 섹션 추가 — `setLocale` 없이 특정 요소만 독립 번역하는 패턴

🤖 Generated with [Claude Code](https://claude.com/claude-code)