### PR TITLE
fix: 텍스트 최소 글자수 제약 제거

### DIFF
--- a/src/client/t.ts
+++ b/src/client/t.ts
@@ -32,9 +32,6 @@ if (!(window as any).__tongues) {
   let initialLocale = "";
   let sourceLang = "";
   let isManual = false;
-  // CJK 언어(한중일)는 1글자도 완전한 의미를 가지므로 최소 길이 1
-  const CJK_LANGS = new Set(["ko", "zh", "ja"]);
-  function minLen() { return CJK_LANGS.has(sourceLang) ? 1 : 2; }
   let preprompt = "";
   let isBusy = false;
   let isDone = false;
@@ -110,7 +107,7 @@ if (!(window as any).__tongues) {
           }
 
           const text = el.textContent?.trim();
-          if (!text || text.length < minLen()) return NodeFilter.FILTER_SKIP;
+          if (!text) return NodeFilter.FILTER_SKIP;
 
           if (el.children.length > 0) {
             if (!hasInlineChildrenOnly(el)) return NodeFilter.FILTER_SKIP;
@@ -136,7 +133,7 @@ if (!(window as any).__tongues) {
         text = el.textContent!.trim();
       }
 
-      if (text && text.length >= minLen()) {
+      if (text) {
         const list = textMap.get(text) || [];
         list.push(el);
         textMap.set(text, list);
@@ -154,7 +151,7 @@ if (!(window as any).__tongues) {
       for (const attr of TRANSLATABLE_ATTRS) {
         const savedOriginal = el.getAttribute(`data-ta-${attr}`);
         const value = (savedOriginal || el.getAttribute(attr))?.trim();
-        if (!value || value.length < minLen() || (incremental && savedOriginal)) continue;
+        if (!value || (incremental && savedOriginal)) continue;
 
         const list = attrMap.get(value) || [];
         list.push({ el, attr });

--- a/src/client/t.ts
+++ b/src/client/t.ts
@@ -32,6 +32,9 @@ if (!(window as any).__tongues) {
   let initialLocale = "";
   let sourceLang = "";
   let isManual = false;
+  // CJK 언어(한중일)는 1글자도 완전한 의미를 가지므로 최소 길이 1
+  const CJK_LANGS = new Set(["ko", "zh", "ja"]);
+  function minLen() { return CJK_LANGS.has(sourceLang) ? 1 : 2; }
   let preprompt = "";
   let isBusy = false;
   let isDone = false;
@@ -107,7 +110,7 @@ if (!(window as any).__tongues) {
           }
 
           const text = el.textContent?.trim();
-          if (!text || text.length < 2) return NodeFilter.FILTER_SKIP;
+          if (!text || text.length < minLen()) return NodeFilter.FILTER_SKIP;
 
           if (el.children.length > 0) {
             if (!hasInlineChildrenOnly(el)) return NodeFilter.FILTER_SKIP;
@@ -133,7 +136,7 @@ if (!(window as any).__tongues) {
         text = el.textContent!.trim();
       }
 
-      if (text && text.length >= 2) {
+      if (text && text.length >= minLen()) {
         const list = textMap.get(text) || [];
         list.push(el);
         textMap.set(text, list);
@@ -151,7 +154,7 @@ if (!(window as any).__tongues) {
       for (const attr of TRANSLATABLE_ATTRS) {
         const savedOriginal = el.getAttribute(`data-ta-${attr}`);
         const value = (savedOriginal || el.getAttribute(attr))?.trim();
-        if (!value || value.length < 2 || (incremental && savedOriginal)) continue;
+        if (!value || value.length < minLen() || (incremental && savedOriginal)) continue;
 
         const list = attrMap.get(value) || [];
         list.push({ el, attr });


### PR DESCRIPTION
## 문제가 뭐였냐면

'술', '밥', '국' 같은 1글자 단어가 번역되지 않았다. \`text.length < 2\` 필터가 1글자를 무조건 스킵했기 때문.

## 수정

길이 제한 자체를 제거. 빈 문자열만 스킵.

\`\`\`ts
// before
if (!text || text.length < 2) return NodeFilter.FILTER_SKIP;

// after
if (!text) return NodeFilter.FILTER_SKIP;
\`\`\`

## 테스트

128/128 통과

Closes #20